### PR TITLE
Issue/abbonamento model dao

### DIFF
--- a/lib/dao/abbonamento_dao.dart
+++ b/lib/dao/abbonamento_dao.dart
@@ -9,11 +9,11 @@ class AbbonamentoDao implements Dao<Abbonamento, String> {
   AbbonamentoDao(this._firestore);
 
   CollectionReference<Abbonamento> get _collection => _firestore
-      .collection(_collectionPath)
-      .withConverter<Abbonamento>(
-        fromFirestore: (snapshot, _) => Abbonamento.fromFirestore(snapshot),
-        toFirestore: (abbonamento, _) => abbonamento.toFirestore(),
-      );
+    .collection(_collectionPath)
+    .withConverter<Abbonamento>(
+      fromFirestore: Abbonamento.fromFirestore,
+      toFirestore: (abbonamento, _) => abbonamento.toFirestore()
+    );
 
   @override
   Future<Abbonamento> create(Abbonamento data) async {
@@ -35,14 +35,17 @@ class AbbonamentoDao implements Dao<Abbonamento, String> {
   @override
   Future<List<Abbonamento>> findAll() async {
     final QuerySnapshot<Abbonamento> snap = await _collection.get();
-    return snap.docs.map((d) => d.data()).toList();
+
+    return snap.docs
+      .map((d) => d.data())
+      .toList();
   }
 
   @override
   Stream<List<Abbonamento>> findAllStream() {
     return _collection.snapshots().map(
       (QuerySnapshot<Abbonamento> query) =>
-          query.docs.map((d) => d.data()).toList(),
+        query.docs.map((d) => d.data()).toList(),
     );
   }
 
@@ -55,9 +58,11 @@ class AbbonamentoDao implements Dao<Abbonamento, String> {
   @override
   Future<Abbonamento> update(Abbonamento data) async {
     final id = data.id;
-    if (id == null) {
+    
+    if (id.isEmpty) {
       throw ArgumentError('Abbonamento.id is required for update');
     }
+    
     final doc = _collection.doc(id);
     await doc.set(data);
     return (await doc.get()).data()!;

--- a/lib/models/abbonamento.dart
+++ b/lib/models/abbonamento.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Abbonamento {
-  final String? id;
+  final String id;
   final String descrizione;
   final double prezzo;
   final int maxAnnunciVendita;
@@ -9,31 +9,13 @@ class Abbonamento {
   final int durataInMesi;
 
   Abbonamento({
-    this.id,
+    this.id = '',
     required this.descrizione,
     required this.prezzo,
     required this.maxAnnunciVendita,
     required this.annunciPriority,
     required this.durataInMesi,
   });
-
-  Abbonamento copyWith({
-    String? id,
-    String? descrizione,
-    double? prezzo,
-    int? maxAnnunciVendita,
-    int? annunciPriority,
-    int? durataInMesi,
-  }) {
-    return Abbonamento(
-      id: id ?? this.id,
-      descrizione: descrizione ?? this.descrizione,
-      prezzo: prezzo ?? this.prezzo,
-      maxAnnunciVendita: maxAnnunciVendita ?? this.maxAnnunciVendita,
-      annunciPriority: annunciPriority ?? this.annunciPriority,
-      durataInMesi: durataInMesi ?? this.durataInMesi,
-    );
-  }
 
   Map<String, dynamic> toFirestore() {
     return {
@@ -45,25 +27,24 @@ class Abbonamento {
     };
   }
 
-  factory Abbonamento.fromMap(Map<String, dynamic> map) {
-    return Abbonamento(
-      id: map['id'] as String?,
-      descrizione: map['descrizione'] as String? ?? '',
-      prezzo: (map['prezzo'] is int)
-          ? (map['prezzo'] as int).toDouble()
-          : (map['prezzo'] as num?)?.toDouble() ?? 0.0,
-      maxAnnunciVendita: (map['maxAnnunciVendita'] as num?)?.toInt() ?? 0,
-      annunciPriority: (map['annunciPriority'] as num?)?.toInt() ?? 0,
-      durataInMesi: (map['durataInMesi'] as num?)?.toInt() ?? 0,
-    );
-  }
-
   factory Abbonamento.fromFirestore(
     DocumentSnapshot<Map<String, dynamic>> snapshot,
+    [SnapshotOptions? options]
   ) {
-    final data = snapshot.data() ?? {};
-    // Ensure id from document id if not present in data
-    final id = (data['id'] as String?) ?? snapshot.id;
-    return Abbonamento.fromMap({...data, 'id': id});
+
+    final data = snapshot.data();
+
+    if(data == null) {
+      throw ArgumentError.notNull("snapshot.data()");
+    }
+
+    return Abbonamento(
+      id: snapshot.id,
+      descrizione: data['descrizione'] as String? ?? '',
+      prezzo: (data['prezzo'] as num?)?.toDouble() ?? 0.0,
+      maxAnnunciVendita: data['maxAnnunciVendita'] as int? ?? 0,
+      annunciPriority: data['annunciPriority'] as int? ?? 0,
+      durataInMesi: data['durataInMesi'] as int? ?? 0 
+    );
   }
 }


### PR DESCRIPTION
This pull request introduces a new data access layer for managing `Abbonamento` (subscription) entities in Firestore, along with the corresponding data model and interface abstraction. The main changes include the implementation of the `AbbonamentoDao` class for CRUD operations, the definition of the `Abbonamento` model with serialization methods, and the creation of a generic DAO interface for consistency across data access objects.

### Data Access Layer Implementation

* Added `AbbonamentoDao` class in `lib/dao/abbonamento_dao.dart` to handle Firestore CRUD operations for `Abbonamento` entities, including create, update, delete, find by ID, find all, and streaming results.
* Introduced generic `Dao` interface in `lib/dao/dao.dart` to standardize data access methods for entities, improving code consistency and reusability.

### Data Model Definition

* Created `Abbonamento` model in `lib/models/abbonamento.dart` with fields, a `copyWith` method, and serialization/deserialization methods (`toFirestore`, `fromMap`, and `fromFirestore`) for Firestore integration.